### PR TITLE
Add Snap Installations

### DIFF
--- a/roles/basics/tasks/main.yml
+++ b/roles/basics/tasks/main.yml
@@ -3,3 +3,14 @@
     name: "{{ basic_utilities }}"
     state: latest
   become: yes
+- name: install well behaved everyday apps
+  snap:
+    name: "{{ everyday_apps }}"
+    state: present
+  become: yes
+- name: install uncouth everyday apps
+  snap:
+    name: "{{ uncouth_everyday_apps }}"
+    state: present
+    classic: yes
+  become: yes

--- a/roles/basics/vars/main.yml
+++ b/roles/basics/vars/main.yml
@@ -17,3 +17,9 @@ basic_utilities:
   - aspell
   - imagemagick
   - vim
+
+everyday_apps:
+  - signal-desktop
+  - discord
+uncouth_everyday_apps:
+  - slack


### PR DESCRIPTION
Adds Snap installation steps for both apps that respect the sandbox and those that do not, both listed out in vars.  Includes Slack, Discord, and Signal as a starting point.  More to follow
