### PR TITLE
Add Dotfile Role

### DIFF
--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: pull dotfiles from github
+  git:
+    repo: https://github.com/savageco/.dotdot.git
+    dest: ~/.dotdot
+
+- name: symlink dotfiles
+  file:
+    src: "~/.dotdot/{{ item }}"
+    dest: "~/{{ item }}"
+    state: link
+  with_items: "{{ dotfiles_to_symlink }}"

--- a/roles/dotfiles/vars/main.yml
+++ b/roles/dotfiles/vars/main.yml
@@ -1,0 +1,4 @@
+---
+
+dotfiles_to_symlink:
+  - .zshrc

--- a/roles/zsh/tasks/main.yml
+++ b/roles/zsh/tasks/main.yml
@@ -23,7 +23,7 @@
   when: not stat_omz_result.stat.exists
 
 - name: Run oh-my-zsh installer
-  shell: /tmp/zsh-installer.sh --unattended
+  shell: /tmp/zsh-installer.sh --unattended --keep-zshrc
   when: not stat_omz_result.stat.exists
 
 - name: Remove the zsh-installer.sh

--- a/workstations.yml
+++ b/workstations.yml
@@ -4,4 +4,5 @@
   roles:
     - basics
     - zsh
+    - dotfiles
 


### PR DESCRIPTION
Adds a dotfile role creating the clone and symlink only for the .zshrc for now.
Also skips the installation of the zshrc file during omz install in order to avoid conflict when creating the link.
Could force over it, but that would be uh, rude, for other future dotfiles.  It should probably complain if trying to blow up other config too.
