### PR TITLE
Fix Repository Cloning Issue for Dotfiles

### DIFF
--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: pull dotfiles from github
   git:
-    repo: https://github.com/savageco/.dotdot.git
+    repo: git@github.com:savageco/.dotdot.git
     dest: ~/.dotdot
 
 - name: symlink dotfiles


### PR DESCRIPTION
Well that was a hitch in my giddyup.  Forgot to clone via ssh instead of https during install, which messes with subsequent ssh actions in the dotfiles repo.
